### PR TITLE
Make DB file configurable via .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ und anschließend über ein Flask-Dashboard ausgewertet.
 ## Funktionen
 
 - Import von Access-Logs mittels `logfile_etl.py`
-- Speicherung der Daten in `accesslog.db`
+- Speicherung der Daten in einer SQLite-Datenbank (Datei via `DB_FILE` definierbar)
 - Web-Dashboard (`analytics_dashboard.py`) mit Übersichten zu Fehlern,
   Bots, Inhaltsaufrufen und UTM-Parametern
 - Datumsfilter und einfache Diagramme mit Plotly
@@ -20,7 +20,7 @@ und anschließend über ein Flask-Dashboard ausgewertet.
    ```bash
    pip install pandas flask paramiko geoip2 plotly
    ```
-3. `.env.example` nach `.env` kopieren und die SFTP-Zugangsdaten anpassen.
+3. `.env.example` nach `.env` kopieren und die SFTP-Zugangsdaten sowie `DB_FILE` anpassen.
 4. Die GeoLite2 City-Datenbank von [MaxMind](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data)
    herunterladen und unter `geo/GeoLite2-City.mmdb` ablegen.
 

--- a/db_utils.py
+++ b/db_utils.py
@@ -1,11 +1,29 @@
 """Hilfsfunktionen und Klassen für Datenbankzugriffe."""
 
+import os
 import sqlite3
 from typing import Iterable, Tuple
 
 import pandas as pd
 
-DB_FILE = "accesslog.db"
+
+def load_env(path: str = ".env") -> None:
+    """Load key=value pairs from a .env file into os.environ."""
+    if not os.path.exists(path):
+        return
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" in line:
+                key, value = line.split("=", 1)
+                os.environ.setdefault(key, value)
+
+
+load_env()
+
+DB_FILE = os.environ.get("DB_FILE", "accesslog.db")
 
 
 def get_df(query: str, params=None, db_file: str = DB_FILE) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
- support DB file name from `.env` in `db_utils.py`
- mention DB_FILE in README instructions and features

## Testing
- `python -m py_compile db_utils.py analytics_dashboard.py logfile_etl.py filters.py geo_utils.py utils.py visualization.py`

------
https://chatgpt.com/codex/tasks/task_e_68404adbaaac832798c4af5c03ee48a7