### PR TITLE
Centralize load_env

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -6,20 +6,7 @@ from typing import Iterable, Tuple
 
 import pandas as pd
 
-
-def load_env(path: str = ".env") -> None:
-    """Load key=value pairs from a .env file into os.environ."""
-    if not os.path.exists(path):
-        return
-    with open(path) as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith("#"):
-                continue
-            if "=" in line:
-                key, value = line.split("=", 1)
-                os.environ.setdefault(key, value)
-
+from utils import load_env
 
 load_env()
 

--- a/logfile_etl.py
+++ b/logfile_etl.py
@@ -7,19 +7,7 @@ from urllib.parse import urlparse, parse_qs
 
 import paramiko
 from db_utils import AccessLogDB
-
-def load_env(path=".env"):
-    """Load key=value pairs from a .env file into os.environ"""
-    if not os.path.exists(path):
-        return
-    with open(path) as f:
-        for line in f:
-            line = line.strip()
-            if not line or line.startswith('#'):
-                continue
-            if '=' in line:
-                key, value = line.split('=', 1)
-                os.environ.setdefault(key, value)
+from utils import load_env
 
 load_env()
 

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,20 @@
+import os
 from datetime import datetime, timedelta, date
 from flask import request, render_template, url_for
+
+
+def load_env(path: str = ".env") -> None:
+    """Load key=value pairs from a .env file into ``os.environ``."""
+    if not os.path.exists(path):
+        return
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" in line:
+                key, value = line.split("=", 1)
+                os.environ.setdefault(key, value)
 
 def render_dashboard(template, tab, params, filter_from, filter_to, **kwargs):
     """


### PR DESCRIPTION
## Summary
- create `load_env` helper in `utils`
- import and use `load_env` in `db_utils` and `logfile_etl`

## Testing
- `python -m py_compile utils.py db_utils.py logfile_etl.py`
- `python -m py_compile analytics_dashboard.py filters.py geo_utils.py visualization.py`


------
https://chatgpt.com/codex/tasks/task_e_68404c3eb17c8327b06b3af40562d16e