### PR TITLE
Move database helpers into class

### DIFF
--- a/analytics_dashboard.py
+++ b/analytics_dashboard.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from flask import Flask, request, redirect, url_for
 from collections import Counter
-from db_utils import load_access_logs
+from db_utils import AccessLogDB
 from geo_utils import GeoIPLookup
 from visualization import to_plotly_figure
 from filters import filter_content_paths, filter_referrers, apply_date_filter
@@ -13,7 +13,7 @@ geoip = GeoIPLookup('./geo/GeoLite2-City.mmdb')
 #--- Hilfsfunktion (zentral, überall identisch) ---
 def get_df_filtered():
     from_date, to_date = get_date_params()
-    df_all = load_access_logs()
+    df_all = AccessLogDB.load_access_logs()
     df_all = apply_date_filter(df_all, from_date, to_date)
     # Flags sauber casten
     if 'is_bot' in df_all:

--- a/db_utils.py
+++ b/db_utils.py
@@ -13,26 +13,6 @@ load_env()
 DB_FILE = os.environ.get("DB_FILE", "accesslog.db")
 
 
-def get_df(query: str, params=None, db_file: str = DB_FILE) -> pd.DataFrame:
-    """Lädt eine Abfrage als DataFrame aus der Datenbank."""
-    with sqlite3.connect(db_file) as con:
-        df = pd.read_sql_query(query, con, params=params)
-    return df
-
-
-def load_access_logs() -> pd.DataFrame:
-    """Lädt sämtliche Zeilen der Tabelle ``access_log`` als DataFrame."""
-    return get_df("SELECT * FROM access_log")
-
-
-def execute(query: str, params=None, db_file: str = DB_FILE) -> None:
-    """Führt eine Änderungsabfrage (INSERT/UPDATE/DELETE) aus."""
-    with sqlite3.connect(db_file) as con:
-        cur = con.cursor()
-        cur.execute(query, params or ())
-        con.commit()
-
-
 class AccessLogDB:
     """Kapselt alle Datenbankoperationen für die Access-Logs."""
 
@@ -64,6 +44,29 @@ class AccessLogDB:
         is_bot, is_admin_tech, is_content, utm_source, utm_medium, utm_campaign
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """
+
+    # ---------------------------------------------------------
+    # Statische Helferfunktionen
+    # ---------------------------------------------------------
+    @staticmethod
+    def get_DataFrame(query: str, params=None, db_file: str = DB_FILE) -> pd.DataFrame:
+        """Lädt eine Abfrage als DataFrame aus der Datenbank."""
+        with sqlite3.connect(db_file) as con:
+            df = pd.read_sql_query(query, con, params=params)
+        return df
+
+    @staticmethod
+    def load_access_logs(db_file: str = DB_FILE) -> pd.DataFrame:
+        """Lädt sämtliche Zeilen der Tabelle ``access_log`` als DataFrame."""
+        return AccessLogDB.get_DataFrame("SELECT * FROM access_log", db_file=db_file)
+
+    @staticmethod
+    def execute(query: str, params=None, db_file: str = DB_FILE) -> None:
+        """Führt eine Änderungsabfrage (INSERT/UPDATE/DELETE) aus."""
+        with sqlite3.connect(db_file) as con:
+            cur = con.cursor()
+            cur.execute(query, params or ())
+            con.commit()
 
     def __init__(self, db_file: str = DB_FILE):
         self.db_file = db_file


### PR DESCRIPTION
## Summary
- group helper functions under `AccessLogDB`
- adjust import and usage in dashboard
- rename `get_df` to `get_DataFrame`

## Testing
- `python -m py_compile db_utils.py analytics_dashboard.py logfile_etl.py filters.py geo_utils.py utils.py visualization.py`

------
https://chatgpt.com/codex/tasks/task_e_68404fa556688327ab17439ec7180db1