### PR TITLE
Add CLI overrides for ETL settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ und anschließend über ein Flask-Dashboard ausgewertet.
 ### Logfiles importieren
 
 ```
-python logfile_etl.py
+python logfile_etl.py [--force-reload] [--no-force-reload] [--mode bulk|daily]
 ```
 
 Dies lädt die Logfiles vom im `.env` definierten Server, parst sie und
-schreibt neue Einträge in die SQLite-Datenbank.
+schreibt neue Einträge in die SQLite-Datenbank. Mit den optionalen
+Parametern `--force-reload`/`--no-force-reload` und `--mode` können die
+entsprechenden Werte aus der `.env` überschrieben werden.
 
 ### Dashboard starten
 

--- a/logfile_etl.py
+++ b/logfile_etl.py
@@ -4,6 +4,7 @@ import gzip
 import shutil
 from datetime import datetime
 from urllib.parse import urlparse, parse_qs
+import argparse
 
 import paramiko
 from db_utils import AccessLogDB
@@ -33,6 +34,23 @@ def get_config():
 
 
 CONFIG = get_config()
+
+
+def parse_args():
+    """Parse command line arguments for optional configuration overrides."""
+    parser = argparse.ArgumentParser(description="Download and import log files")
+    parser.add_argument(
+        "--force-reload",
+        dest="force_reload",
+        action=argparse.BooleanOptionalAction,
+        help="Override FORCE_RELOAD from .env",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["bulk", "daily"],
+        help="Override MODE from .env",
+    )
+    return parser.parse_args()
 
 # Vorab kompilierte Pattern für Logzeilen und Bot-Erkennung
 LOG_PATTERN = re.compile(
@@ -316,4 +334,11 @@ def main(config=CONFIG):
 
 
 if __name__ == "__main__":
-    main()
+    args = parse_args()
+    config = CONFIG.copy()
+    if args.force_reload is not None:
+        config["force_reload"] = args.force_reload
+    if args.mode:
+        config["mode"] = args.mode
+    main(config)
+


### PR DESCRIPTION
## Summary
- allow `force_reload` and `mode` to be passed via command line
- document the new options in the README

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684058d0b8f48327b0732d20718b3626