### PR TITLE
Fix README example for force reload flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,15 @@ python logfile_etl.py [--force-reload] [--no-force-reload] [--mode bulk|daily]
 
 Dies lädt die Logfiles vom im `.env` definierten Server, parst sie und
 schreibt neue Einträge in die SQLite-Datenbank. Mit den optionalen
-Parametern `--force-reload`/`--no-force-reload` und `--mode` können die
+Parametern `--force-reload`/`--no-force-reload` sowie `--mode` können die
 entsprechenden Werte aus der `.env` überschrieben werden.
+
+Beispielaufruf, um den Modus auf `bulk` zu setzen und `force_reload`
+auf `false` zu stellen:
+
+```bash
+python logfile_etl.py --mode bulk --no-force-reload
+```
 
 ### Dashboard starten
 


### PR DESCRIPTION
## Summary
- document `--no-force-reload` flag again
- show example call with that option

## Testing
- `python -m py_compile logfile_etl.py`
- `python -m py_compile analytics_dashboard.py db_utils.py filters.py geo_utils.py utils.py visualization.py`


------
https://chatgpt.com/codex/tasks/task_e_68405b23e9d08327bfc16fd7ee58de9c