### PR TITLE
Unify admin path prefixes

### DIFF
--- a/filters.py
+++ b/filters.py
@@ -1,12 +1,13 @@
-IGNORED_PATHS = [
-    "/wp-includes/",
-    "/wp-content/",
-    "/wp-json/",
+IGNORED_PATH_PREFIXES = (
+    "/wp-includes",
+    "/wp-content",
+    "/wp-json",
     "/xmlrpc.php",
     "/wp-admin",
     "/wp-login.php",
     "/wp-cron.php",
-]
+    "/robots.txt",
+)
 IGNORED_REFERRERS = [
     "leichtgesagt.blog",
     "leicht-gesagt.blog",
@@ -17,8 +18,7 @@ IGNORED_REFERRERS = [
 
 def filter_content_paths(df):
     """Filtert technische Pfade aus dem DataFrame."""
-    prefixes = tuple(IGNORED_PATHS)
-    return df[~df["path"].str.startswith(prefixes)]
+    return df[~df["path"].str.startswith(IGNORED_PATH_PREFIXES)]
 
 
 def filter_referrers(df):

--- a/logfile_etl.py
+++ b/logfile_etl.py
@@ -9,6 +9,7 @@ import argparse
 import paramiko
 from db_utils import AccessLogDB
 from utils import load_env
+from filters import IGNORED_PATH_PREFIXES
 
 load_env()
 
@@ -242,17 +243,7 @@ def is_bot(user_agent):
 
 def is_admin_tech(path):
     """True, wenn der Pfad zu administrativen WordPress-Bereichen gehört."""
-    admin_patterns = (
-        "/wp-admin",
-        "/wp-login.php",
-        "/wp-json",
-        "/wp-content",
-        "/xmlrpc.php",
-        "/wp-cron.php",
-        "/wp-includes",
-        "/robots.txt",
-    )
-    return path.startswith(admin_patterns)
+    return path.startswith(IGNORED_PATH_PREFIXES)
 
 
 def extract_utm(referrer):


### PR DESCRIPTION
## Summary
- centralize list of ignored path prefixes in `filters.py`
- reuse this constant in `logfile_etl.is_admin_tech`

## Testing
- `python -m py_compile analytics_dashboard.py filters.py utils.py db_utils.py geo_utils.py logfile_etl.py`

------
https://chatgpt.com/codex/tasks/task_e_6840607cd8388327af978bb419492336