### PR TITLE
Add index creation on table reload

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -38,6 +38,19 @@ class AccessLogDB:
     )
     """
 
+    INDEX_SQLS = [
+        """CREATE UNIQUE INDEX IF NOT EXISTS access_log_id_uindex
+        ON access_log (id)""",
+        """CREATE INDEX IF NOT EXISTS access_log_is_admin_tech_index
+        ON access_log (is_admin_tech)""",
+        """CREATE INDEX IF NOT EXISTS access_log_is_bot_index
+        ON access_log (is_bot)""",
+        """CREATE INDEX IF NOT EXISTS access_log_is_content_index
+        ON access_log (is_content)""",
+        """CREATE INDEX IF NOT EXISTS access_log_timestamp_index
+        ON access_log (timestamp)""",
+    ]
+
     INSERT_SQL = """
     INSERT OR IGNORE INTO access_log (
         timestamp, ip, method, path, query, status, size, referrer, user_agent,
@@ -86,6 +99,9 @@ class AccessLogDB:
         if force_reload:
             self._cur.execute("DROP TABLE IF EXISTS access_log")
         self._cur.execute(self.TABLE_SQL)
+        if force_reload:
+            for stmt in self.INDEX_SQLS:
+                self._cur.execute(stmt)
         self._con.commit()
 
     def insert_logs(self, records: Iterable[Tuple]) -> int:


### PR DESCRIPTION
## Summary
- create index definitions in `AccessLogDB`
- add optional index creation during `init_db` when force reloading the DB

## Testing
- `python -m py_compile *.py`
- `python -m py_compile db_utils.py logfile_etl.py analytics_dashboard.py geo_utils.py filters.py utils.py visualization.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6840a1dbdc0c8327a1bd9fb36c8dc35b