### PR TITLE
Add unit tests for ETL and dashboard modules

### DIFF
--- a/tests/test_analytics_dashboard.py
+++ b/tests/test_analytics_dashboard.py
@@ -1,0 +1,59 @@
+import types
+import sys
+
+import pytest
+
+# Provide a minimal pandas stub before importing the module
+pandas_stub = types.ModuleType("pandas")
+pandas_stub.DataFrame = dict
+sys.modules.setdefault("pandas", pandas_stub)
+
+import analytics_dashboard as ad
+
+
+def test_root_redirect():
+    client = ad.app.test_client()
+    resp = client.get("/")
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/overview")
+
+
+class FakeSeries(list):
+    def astype(self, typ):
+        return FakeSeries([typ(x) if x is not None else 0 for x in self])
+
+    def fillna(self, val):
+        return FakeSeries([val if x is None else x for x in self])
+
+
+class FakeDataFrame(dict):
+    def __contains__(self, item):
+        return dict.__contains__(self, item)
+
+    def __getitem__(self, item):
+        return dict.__getitem__(self, item)
+
+    def __setitem__(self, key, value):
+        dict.__setitem__(self, key, value)
+
+
+def test_get_df_filtered(monkeypatch):
+    df = FakeDataFrame({
+        "is_bot": FakeSeries([0, 1]),
+        "is_content": FakeSeries([1, 0]),
+        "is_admin_tech": FakeSeries([0, None]),
+    })
+
+    monkeypatch.setattr(ad.AccessLogDB, "load_access_logs", staticmethod(lambda: df))
+    monkeypatch.setattr(ad, "apply_date_filter", lambda d, f, t: d)
+    monkeypatch.setattr(ad, "get_date_params", lambda: ("2021-01-01", "2021-01-31"))
+
+    with ad.app.test_request_context("/overview"):
+        result_df, params, f_from, f_to = ad.get_df_filtered()
+
+    assert isinstance(result_df, FakeDataFrame)
+    assert result_df["is_admin_tech"] == [0, 0]
+    assert f_from == "2021-01-01"
+    assert f_to == "2021-01-31"
+    assert params == {}
+

--- a/tests/test_logfile_etl.py
+++ b/tests/test_logfile_etl.py
@@ -1,0 +1,43 @@
+import tempfile
+from pathlib import Path
+
+import logfile_etl as le
+
+
+def test_extract_utm():
+    url = "http://example.com/?utm_source=google&utm_medium=cpc&utm_campaign=test"
+    assert le.extract_utm(url) == ("google", "cpc", "test")
+
+
+def test_extract_utm_none():
+    assert le.extract_utm(None) == (None, None, None)
+    assert le.extract_utm("-") == (None, None, None)
+
+
+def test_is_admin_tech():
+    assert le.is_admin_tech("/wp-admin/edit.php")
+    assert not le.is_admin_tech("/blog/post")
+
+
+def test_process_logfile(monkeypatch, tmp_path):
+    log_path = tmp_path / "access.log"
+    log_lines = [
+        "127.0.0.1 - - [01/Jan/2021:10:00:00 +0000] \"GET /blog/page.html?utm_source=google&utm_medium=ad&utm_campaign=test HTTP/1.1\" 200 1000 example.com \"http://example.com/\" \"Mozilla/5.0\" \"-\"",
+        "127.0.0.2 - - [01/Jan/2021:11:00:00 +0000] \"GET /wp-admin/admin.php HTTP/1.1\" 404 0 example.com \"-\" \"BotAgent\" \"-\"",
+    ]
+    log_path.write_text("\n".join(log_lines))
+    monkeypatch.setattr(le, "is_bot", lambda ua: ua == "BotAgent")
+    records = le.process_logfile(str(log_path))
+    assert len(records) == 2
+    rec1, rec2 = records
+    assert rec1[0] == "2021-01-01T10:00:00"
+    assert rec1[3] == "/blog/page.html"
+    assert rec1[8] == "Mozilla/5.0"
+    assert rec1[9] is False
+    assert rec1[10] is False
+    assert rec1[11] is True
+    assert rec1[12:15] == ["google", "ad", "test"]
+    assert rec2[9] is True
+    assert rec2[10] is True
+    assert rec2[11] is False
+


### PR DESCRIPTION
## Summary
- add unit tests for logfile_etl helper functions
- add basic tests for analytics_dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for flask, paramiko)*

------
https://chatgpt.com/codex/tasks/task_e_6840a67b11a88327a5558ed269dd95d8