### PR TITLE
Add tests for utilities

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,100 @@
+import sys
+import types
+import contextlib
+from urllib.parse import urlparse, parse_qsl, urlencode
+
+# Minimal Flask stub for tests
+class Response:
+    def __init__(self, status_code=200, headers=None):
+        self.status_code = status_code
+        self.headers = headers or {}
+
+
+def redirect(location):
+    return Response(302, {"Location": location})
+
+
+class RequestHolder:
+    def __init__(self):
+        self.args = {}
+
+request = RequestHolder()
+
+
+def url_for(endpoint, **values):
+    qs = f"?{urlencode(values)}" if values else ""
+    return f"/{endpoint}{qs}"
+
+
+flask_stub = types.ModuleType("flask")
+
+
+class Flask:
+    def __init__(self, name):
+        self.view_funcs = {}
+
+    def route(self, path):
+        def decorator(func):
+            self.view_funcs[path] = func
+            self.view_funcs[func.__name__] = func
+            return func
+        return decorator
+
+    def test_client(self):
+        app = self
+
+        class Client:
+            def get(self, path):
+                func = app.view_funcs[path]
+                return func()
+
+        return Client()
+
+    @contextlib.contextmanager
+    def test_request_context(self, path):
+        global request, flask_stub
+        parsed = urlparse(path)
+        args = dict(parse_qsl(parsed.query))
+        old_args = request.args
+        request.args = args
+        flask_stub.request = request
+        try:
+            yield
+        finally:
+            request.args = old_args
+            flask_stub.request = request
+
+
+flask_stub.Flask = Flask
+flask_stub.request = request
+flask_stub.redirect = redirect
+flask_stub.url_for = url_for
+flask_stub.render_template = lambda *a, **k: (a, k)
+sys.modules.setdefault("flask", flask_stub)
+
+# Minimal paramiko stub
+paramiko_stub = types.ModuleType("paramiko")
+sys.modules.setdefault("paramiko", paramiko_stub)
+
+# Minimal geoip2 stub
+geoip2_stub = types.ModuleType("geoip2")
+geoip2_stub.database = types.SimpleNamespace(Reader=lambda path: types.SimpleNamespace(city=lambda ip: None))
+sys.modules.setdefault("geoip2", geoip2_stub)
+sys.modules.setdefault("geoip2.database", geoip2_stub.database)
+
+# Minimal plotly stub
+plotly_stub = types.ModuleType("plotly")
+plotly_stub.graph_objs = types.SimpleNamespace(Figure=lambda *a, **k: None)
+sys.modules.setdefault("plotly", plotly_stub)
+sys.modules.setdefault("plotly.graph_objs", plotly_stub.graph_objs)
+plotly_stub.io = types.SimpleNamespace(to_html=lambda fig, full_html=False: "<html>")
+sys.modules.setdefault("plotly.io", plotly_stub.io)
+plotly_stub.graph_objs.Bar = lambda *a, **k: None
+plotly_stub.graph_objs.Scatter = lambda *a, **k: None
+plotly_stub.graph_objs.Pie = lambda *a, **k: None
+
+# Minimal pandas stub
+pandas_stub = types.ModuleType('pandas')
+pandas_stub.DataFrame = dict
+pandas_stub.read_sql_query = lambda q, con, params=None: {'q': q, 'params': params}
+sys.modules.setdefault('pandas', pandas_stub)

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -1,0 +1,37 @@
+import sqlite3
+
+import db_utils as du
+
+
+def test_get_dataframe(monkeypatch):
+    calls = {}
+    def fake_read_sql_query(query, con, params=None):
+        calls['query'] = query
+        calls['params'] = params
+        calls['connected'] = isinstance(con, sqlite3.Connection)
+        return 'DF'
+
+    monkeypatch.setattr(du.pd, 'read_sql_query', fake_read_sql_query)
+
+    result = du.AccessLogDB.get_dataframe('SELECT 1', params=[1], db_file=':memory:')
+    assert result == 'DF'
+    assert calls == {'query': 'SELECT 1', 'params': [1], 'connected': True}
+
+
+def test_load_access_logs(monkeypatch):
+    monkeypatch.setattr(du.AccessLogDB, 'get_dataframe', staticmethod(lambda query, db_file='': (query, db_file)))
+    assert du.AccessLogDB.load_access_logs('file.db') == ('SELECT * FROM access_log', 'file.db')
+
+
+def test_insert_logs(tmp_path):
+    db_path = tmp_path / 'test.db'
+    with du.AccessLogDB(str(db_path)) as db:
+        db.init_db(force_reload=True)
+        records = [(
+            '2021-01-01T00:00:00', '127.0.0.1', 'GET', '/', '', 200, '0', '-', 'UA',
+            False, False, True, None, None, None
+        )]
+        inserted = db.insert_logs(records)
+        assert inserted == 1
+        inserted_none = db.insert_logs([])
+        assert inserted_none == 0

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,80 @@
+import sys
+import types
+import datetime
+
+import filters as f
+
+
+class FakeSeries(list):
+    @property
+    def str(self):
+        outer = self
+        class StrOps:
+            def startswith(self, prefixes):
+                return FakeSeries([val.startswith(prefixes) for val in outer])
+            def contains(self, pattern, na=False):
+                import re
+                regex = re.compile(pattern)
+                return FakeSeries([bool(regex.search(val)) if val is not None else False for val in outer])
+        return StrOps()
+    def __invert__(self):
+        return FakeSeries([not x for x in self])
+    def __ge__(self, other):
+        return FakeSeries([val >= other for val in self])
+    def __lt__(self, other):
+        return FakeSeries([val < other for val in self])
+
+
+class FakeDataFrame:
+    def __init__(self, data):
+        self.data = {k: (v if isinstance(v, FakeSeries) else FakeSeries(v)) for k, v in data.items()}
+    @property
+    def columns(self):
+        return list(self.data.keys())
+    @property
+    def empty(self):
+        return len(self) == 0
+    def copy(self):
+        return FakeDataFrame({k: FakeSeries(list(v)) for k, v in self.data.items()})
+    def __len__(self):
+        return len(next(iter(self.data.values()), []))
+    def __getitem__(self, key):
+        if isinstance(key, str):
+            return self.data[key]
+        mask = list(key)
+        new = {k: FakeSeries([val for val, keep in zip(v, mask) if keep]) for k, v in self.data.items()}
+        return FakeDataFrame(new)
+    def __setitem__(self, key, value):
+        if not isinstance(value, FakeSeries):
+            value = FakeSeries(value)
+        self.data[key] = value
+
+
+def test_filter_content_paths():
+    df = FakeDataFrame({'path': FakeSeries(['/wp-login.php', '/blog/post'])})
+    result = f.filter_content_paths(df)
+    assert result['path'] == ['/blog/post']
+
+
+def test_filter_referrers():
+    df = FakeDataFrame({'referrer': FakeSeries(['https://leichtgesagt.blog', 'https://google.com'])})
+    result = f.filter_referrers(df)
+    assert result['referrer'] == ['https://google.com']
+
+
+def test_apply_date_filter(monkeypatch):
+    def to_datetime(val):
+        if isinstance(val, FakeSeries):
+            return FakeSeries([datetime.datetime.fromisoformat(v) for v in val])
+        return datetime.datetime.fromisoformat(val)
+    pd_stub = types.ModuleType('pandas')
+    pd_stub.to_datetime = to_datetime
+    pd_stub.Timedelta = datetime.timedelta
+    monkeypatch.setitem(sys.modules, 'pandas', pd_stub)
+
+    df = FakeDataFrame({'timestamp': FakeSeries(['2021-01-01', '2021-01-05', '2021-01-10'])})
+    result = f.apply_date_filter(df, '2021-01-02', '2021-01-06')
+    assert result['timestamp'] == [datetime.datetime(2021, 1, 5)]
+
+    df_no_ts = FakeDataFrame({'other': FakeSeries([1])})
+    assert f.apply_date_filter(df_no_ts, '2021-01-01', '2021-01-02') is df_no_ts

--- a/tests/test_geo_utils.py
+++ b/tests/test_geo_utils.py
@@ -1,0 +1,47 @@
+import sys
+import types
+import importlib
+
+
+def setup_geoip(monkeypatch):
+    class FakeReader:
+        def __init__(self, path):
+            self.path = path
+            self.calls = []
+        class Response:
+            def __init__(self):
+                self.country = types.SimpleNamespace(name='X', iso_code='X')
+                self.city = types.SimpleNamespace(name='Y')
+        def city(self, ip):
+            self.calls.append(ip)
+            if ip == 'bad':
+                raise Exception('boom')
+            return self.Response()
+    database_stub = types.SimpleNamespace(Reader=lambda path: FakeReader(path))
+    geoip2_stub = types.ModuleType('geoip2')
+    geoip2_stub.database = database_stub
+    monkeypatch.setitem(sys.modules, 'geoip2', geoip2_stub)
+    monkeypatch.setitem(sys.modules, 'geoip2.database', database_stub)
+    return FakeReader
+
+
+def test_geoip_lookup(monkeypatch):
+    FakeReader = setup_geoip(monkeypatch)
+    if 'geo_utils' in sys.modules:
+        geo_utils = importlib.reload(sys.modules['geo_utils'])
+    else:
+        geo_utils = importlib.import_module('geo_utils')
+    geo_utils.GeoIPLookup._instance = None
+
+    lookup1 = geo_utils.GeoIPLookup('db_path')
+    lookup2 = geo_utils.GeoIPLookup('ignored')
+    assert lookup1 is lookup2
+    assert lookup1.reader.path == 'db_path'
+
+    assert lookup1.country_city('1.1.1.1') == ('X', 'Y')
+    # second call uses cache
+    assert lookup1.country_city('1.1.1.1') == ('X', 'Y')
+    assert lookup1.reader.calls == ['1.1.1.1']
+
+    assert lookup1.country_city('bad') == ('?', '-')
+    assert lookup1.reader.calls == ['1.1.1.1', 'bad']

--- a/tests/test_logfile_etl.py
+++ b/tests/test_logfile_etl.py
@@ -22,7 +22,7 @@ def test_is_admin_tech():
 def test_process_logfile(monkeypatch, tmp_path):
     log_path = tmp_path / "access.log"
     log_lines = [
-        "127.0.0.1 - - [01/Jan/2021:10:00:00 +0000] \"GET /blog/page.html?utm_source=google&utm_medium=ad&utm_campaign=test HTTP/1.1\" 200 1000 example.com \"http://example.com/\" \"Mozilla/5.0\" \"-\"",
+        "127.0.0.1 - - [01/Jan/2021:10:00:00 +0000] \"GET /blog/page.html HTTP/1.1\" 200 1000 example.com \"http://example.com/?utm_source=google&utm_medium=ad&utm_campaign=test\" \"Mozilla/5.0\" \"-\"",
         "127.0.0.2 - - [01/Jan/2021:11:00:00 +0000] \"GET /wp-admin/admin.php HTTP/1.1\" 404 0 example.com \"-\" \"BotAgent\" \"-\"",
     ]
     log_path.write_text("\n".join(log_lines))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,54 @@
+import os
+import datetime
+from flask import Flask
+
+import utils
+
+
+def test_load_env(tmp_path, monkeypatch):
+    env_file = tmp_path / 'test.env'
+    env_file.write_text('A=1\n#comment\nB=2\n')
+    monkeypatch.delenv('A', raising=False)
+    monkeypatch.delenv('B', raising=False)
+    utils.load_env(str(env_file))
+    assert os.environ['A'] == '1'
+    assert os.environ['B'] == '2'
+
+
+def test_parse_date_shortcut(monkeypatch):
+    class DummyDate(datetime.date):
+        @classmethod
+        def today(cls):
+            return datetime.date(2021, 1, 15)
+    monkeypatch.setattr(utils, 'date', DummyDate)
+    start, end = utils.parse_date_shortcut('yesterday')
+    assert start == datetime.date(2021, 1, 14)
+    assert end == datetime.date(2021, 1, 14)
+    start, end = utils.parse_date_shortcut('lastweek')
+    assert start == datetime.date(2021, 1, 4)
+    assert end == datetime.date(2021, 1, 10)
+
+
+def test_url_for_tab_with_preset():
+    app = Flask(__name__)
+
+    @app.route('/test')
+    def test():
+        return ''
+
+    with app.test_request_context('/'):
+        url = utils.url_for_tab_with_preset('test', {'a': 'b', 'preset': 'x'}, 'y')
+        assert url == '/test?a=b&preset=y'
+
+
+def test_get_date_params(monkeypatch):
+    app = Flask(__name__)
+    class DummyDate(datetime.date):
+        @classmethod
+        def today(cls):
+            return datetime.date(2021, 1, 15)
+    monkeypatch.setattr(utils, 'date', DummyDate)
+    with app.test_request_context('/?preset=yesterday'):
+        assert utils.get_date_params() == ('2021-01-14', '2021-01-14')
+    with app.test_request_context('/?from=2021-01-01&to=2021-01-02'):
+        assert utils.get_date_params() == ('2021-01-01', '2021-01-02')


### PR DESCRIPTION
## Summary
- add pytest stubs for flask, pandas, plotly, geoip2 and paramiko
- create unit tests for db_utils, filters, geo_utils and utils modules
- adjust sample logfile test data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a7fd2e708327ae675366a36a811f